### PR TITLE
Wasm stdout stderr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,7 @@ FROM base AS wasmcc
 WORKDIR /tmp/wasmer
 RUN curl -sSL https://github.com/wasmerio/wasmer/releases/download/0.17.1/wasmer-c-api-linux-amd64.tar.gz | tar xzf -
 WORKDIR /tmp/wasmcc
-RUN git clone -b client-server https://github.com/jt-nti/fabric-chaincode-wasm.git \
+RUN git clone https://github.com/hyperledgendary/fabric-chaincode-wasm.git \
     && cd fabric-chaincode-wasm \
     && go get -d -v ./... \
     && go install -v ./...

--- a/builders/wasm/bin/build
+++ b/builders/wasm/bin/build
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd -P)
+
+CHAINCODE_SOURCE_DIR="$1"
+CHAINCODE_METADATA_DIR="$2"
+BUILD_OUTPUT_DIR="$3"
+
+cd "${CHAINCODE_SOURCE_DIR}/src"
+tar cf - . | (cd "${BUILD_OUTPUT_DIR}" && tar xf -)

--- a/builders/wasm/bin/detect
+++ b/builders/wasm/bin/detect
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+CHAINCODE_METADATA_DIR="$2"
+if [ "$(jq -r .type "${CHAINCODE_METADATA_DIR}/metadata.json" | tr '[:upper:]' '[:lower:]')" = "wasm" ]; then
+    exit 0
+fi
+exit 1

--- a/builders/wasm/bin/release
+++ b/builders/wasm/bin/release
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+BUILD_OUTPUT_DIR="$1"
+RELEASE_OUTPUT_DIR="$2"
+if [ -d "${BUILD_OUTPUT_DIR}/META-INF" ] ; then
+   cp -a "${BUILD_OUTPUT_DIR}/META-INF/"* "${RELEASE_OUTPUT_DIR}/"
+fi

--- a/builders/wasm/bin/run
+++ b/builders/wasm/bin/run
@@ -10,4 +10,4 @@ CORE_PEER_LOCALMSPID="$(jq -r .mspid "${RUN_METADATA_DIR}/chaincode.json")"
 CHAINCODE_WASM_FILE=$(ls -d "${BUILD_OUTPUT_DIR}/"*.wasm | head -1)
 CORE_PEER_TLS_ENABLED=false
 export CORE_CHAINCODE_ID_NAME CORE_PEER_LOCALMSPID CHAINCODE_WASM_FILE CORE_PEER_TLS_ENABLED
-exec fabric-chaincode-wasm -peer.address="$(jq -r .peer_address "${RUN_METADATA_DIR}/chaincode.json")"
+exec fabric-chaincode-wasm -peer.address="$(jq -r .peer_address "${RUN_METADATA_DIR}/chaincode.json")" >&2

--- a/builders/wasm/bin/run
+++ b/builders/wasm/bin/run
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+set -euo pipefail
+BUILD_OUTPUT_DIR="$1"
+RUN_METADATA_DIR="$2"
+CORE_CHAINCODE_ID_NAME="$(jq -r .chaincode_id "${RUN_METADATA_DIR}/chaincode.json")"
+CORE_PEER_LOCALMSPID="$(jq -r .mspid "${RUN_METADATA_DIR}/chaincode.json")"
+CHAINCODE_WASM_FILE=$(ls -d "${BUILD_OUTPUT_DIR}/"*.wasm | head -1)
+CORE_PEER_TLS_ENABLED=false
+export CORE_CHAINCODE_ID_NAME CORE_PEER_LOCALMSPID CHAINCODE_WASM_FILE CORE_PEER_TLS_ENABLED
+exec fabric-chaincode-wasm -peer.address="$(jq -r .peer_address "${RUN_METADATA_DIR}/chaincode.json")"

--- a/internal/pkg/peer/runtime.go
+++ b/internal/pkg/peer/runtime.go
@@ -207,6 +207,13 @@ func (p *Peer) createConfig(dataDirectory, mspDirectory string) error {
 				"HOME",
 			},
 		},
+		{
+			"path": path.Join(homeDirectory, "builders", "wasm"),
+			"name": "wasm",
+			"propagateEnvironment": []string{
+				"HOME",
+			},
+		},
 	}
 	configData, err = yaml.Marshal(config)
 	if err != nil {


### PR DESCRIPTION
Peer only captures stderr from the builders. Redirecting stdout to stderr