### PR TITLE
[#62] Use Gradle Wrapper rather than full gradle

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,12 @@ ENV npm_config_devdir=/tmp/npm-devdir
 ENV PATH=/opt/go/bin:/opt/node/bin:/opt/java/bin:${PATH}
 RUN curl -sSL -o /tmp/gradle.zip https://services.gradle.org/distributions/gradle-5.6.4-bin.zip \
     && unzip -qq /tmp/gradle.zip -d /opt \
-    && mv /opt/gradle-5.6.4 /opt/gradle \
+    && mkdir -p /opt/gradle/bin \
+    && cd /opt/gradle/bin       \
+    && /opt/gradle-5.6.4/bin/gradle wrapper \
     && rm -f /tmp/gradle.zip \
+    && rm -rf /opt/gradle-5.6.4 \
+    && cd - \
     && curl -sSL https://downloads.apache.org/maven/maven-3/3.6.3/binaries/apache-maven-3.6.3-bin.tar.gz | tar xzf - -C /opt \
     && mv /opt/apache-maven-3.6.3 /opt/maven
 ENV PATH=/opt/gradle/bin:/opt/maven/bin:${PATH}

--- a/builders/java/bin/build
+++ b/builders/java/bin/build
@@ -11,9 +11,9 @@ cd "${CHAINCODE_SOURCE_DIR}/src"
 if [ -f build.gradle ] || [ -f build.gradle.kts ]; then
     if [ -f ./gradlew ]; then
         chmod +x ./gradlew
-        ./gradlew build shadowJar
+        ./gradlew build shadowJar -x test
     else
-        gradle build shadowJar
+        /opt/gradle/bin/gradlew build shadowJar -x test
     fi
     cp build/libs/chaincode.jar "${BUILD_OUTPUT_DIR}/"
     touch "${BUILD_OUTPUT_DIR}/.uberjar"


### PR DESCRIPTION
Install the gradle wrapper in the docker image, and use that in favour
of the full tool.

Full version will be downloaded at build time

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>