### PR TITLE
Initial TLS support (contributes to #43)

### DIFF
--- a/internal/app/microfabd/config.go
+++ b/internal/app/microfabd/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	CouchDB                bool           `json:"couchdb"`
 	CertificateAuthorities bool           `json:"certificate_authorities"`
 	TimeoutString          string         `json:"timeout"`
+	TLS                    bool           `json:"tls"`
 	Timeout                time.Duration  `json:"-"`
 }
 
@@ -72,6 +73,7 @@ func DefaultConfig() (*Config, error) {
 		CouchDB:                true,
 		CertificateAuthorities: true,
 		TimeoutString:          "30s",
+		TLS:                    false,
 	}
 	if env, ok := os.LookupEnv("MICROFAB_CONFIG"); ok {
 		err := json.Unmarshal([]byte(env), config)

--- a/internal/pkg/ca/ca.go
+++ b/internal/pkg/ca/ca.go
@@ -24,6 +24,7 @@ type CA struct {
 	operationsPort int32
 	operationsURL  *url.URL
 	command        *exec.Cmd
+	tls            *identity.Identity
 }
 
 // New creates a new CA.
@@ -37,7 +38,17 @@ func New(organization *organization.Organization, directory string, apiPort int3
 	if err != nil {
 		return nil, err
 	}
-	return &CA{organization, identity, directory, apiPort, parsedAPIURL, operationsPort, parsedOperationsURL, nil}, nil
+	return &CA{organization, identity, directory, apiPort, parsedAPIURL, operationsPort, parsedOperationsURL, nil, nil}, nil
+}
+
+// TLS gets the TLS identity for this CA.
+func (c *CA) TLS() *identity.Identity {
+	return c.tls
+}
+
+// EnableTLS enables TLS for this CA.
+func (c *CA) EnableTLS(tls *identity.Identity) {
+	c.tls = tls
 }
 
 // Organization returns the organization of the CA.
@@ -72,8 +83,12 @@ func (c *CA) APIPort(internal bool) int32 {
 
 // APIURL returns the API URL of the CA.
 func (c *CA) APIURL(internal bool) *url.URL {
+	scheme := "http"
+	if c.tls != nil {
+		scheme = "https"
+	}
 	if internal {
-		url, _ := url.Parse(fmt.Sprintf("http://localhost:%d", c.apiPort))
+		url, _ := url.Parse(fmt.Sprintf("%s://localhost:%d", scheme, c.apiPort))
 		return url
 	}
 	return c.apiURL
@@ -98,8 +113,12 @@ func (c *CA) OperationsPort(internal bool) int32 {
 
 // OperationsURL returns the operations URL of the CA.
 func (c *CA) OperationsURL(internal bool) *url.URL {
+	scheme := "http"
+	if c.tls != nil {
+		scheme = "https"
+	}
 	if internal {
-		url, _ := url.Parse(fmt.Sprintf("http://localhost:%d", c.operationsPort))
+		url, _ := url.Parse(fmt.Sprintf("%s://localhost:%d", scheme, c.operationsPort))
 		return url
 	}
 	return c.operationsURL

--- a/internal/pkg/couchdb/couchdb.go
+++ b/internal/pkg/couchdb/couchdb.go
@@ -48,7 +48,7 @@ func (c *CouchDB) WaitFor(timeout time.Duration) error {
 	}
 }
 
-// URL returns the URL of the CouchDB.
+// URL returns the URL of the CouchDB instance.
 func (c *CouchDB) URL(internal bool) *url.URL {
 	if internal {
 		return c.internalURL

--- a/internal/pkg/peer/connection.go
+++ b/internal/pkg/peer/connection.go
@@ -5,12 +5,14 @@
 package peer
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/url"
 
 	"github.com/IBM-Blockchain/microfab/internal/pkg/identity"
 	"github.com/IBM-Blockchain/microfab/pkg/client"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 )
 
 // Connection represents a connection to a peer.
@@ -23,7 +25,16 @@ type Connection struct {
 
 // Connect opens a connection to the peer.
 func Connect(peer *Peer, mspID string, identity *identity.Identity) (*Connection, error) {
-	clientConn, err := grpc.Dial(fmt.Sprintf("localhost:%d", peer.apiPort), grpc.WithInsecure())
+	var clientConn *grpc.ClientConn
+	var err error
+	if peer.tls != nil {
+		creds := credentials.NewTLS(&tls.Config{
+			InsecureSkipVerify: true,
+		})
+		clientConn, err = grpc.Dial(fmt.Sprintf("localhost:%d", peer.apiPort), grpc.WithTransportCredentials(creds))
+	} else {
+		clientConn, err = grpc.Dial(fmt.Sprintf("localhost:%d", peer.apiPort), grpc.WithInsecure())
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Specify `MICROFAB_CONFIG='{"port":8443,"tls":true}'` to enable TLS.

The TLS certificates are currently automatically generated and self
signed. A subsequent commit will allow you to specify the TLS
certificates in the configuration.

The same TLS certificates are used for all components. If you think
this is not suitable or safe, you should probably not be using this.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>