### PR TITLE
Enable chaincode-dev-mode on the peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,15 @@ The configuration is a JSON object with the following keys:
         "ca": null // Optional: the TLS CA certificate to be used.
       }
 
+- `chaincode_dev_mode:
+
+  Puts the peer into 'chaincode dev mode'.  This means that the chaincode does not need to be installed, but must
+  be running before it is approved/committed (though it still can be if you wish)
+
+  This cannot be enabled at the same time as TLS. It is also NOT the Chaincode-as-a-server feature. 
+
+  Default: `true`
+
 ## Examples
 
 Configuration example for enabling TLS:

--- a/internal/app/microfabd/config.go
+++ b/internal/app/microfabd/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	TimeoutString          string         `json:"timeout"`
 	TLS                    TLS            `json:"tls"`
 	Timeout                time.Duration  `json:"-"`
+	ChaincodeDevMode       bool           `json:"chaincode_dev_mode"`
 }
 
 // DefaultConfig returns the default configuration.
@@ -84,6 +85,7 @@ func DefaultConfig() (*Config, error) {
 		TLS: TLS{
 			Enabled: false,
 		},
+		ChaincodeDevMode: true,
 	}
 	if env, ok := os.LookupEnv("MICROFAB_CONFIG"); ok {
 		err := json.Unmarshal([]byte(env), config)
@@ -93,6 +95,9 @@ func DefaultConfig() (*Config, error) {
 	}
 	if config.Port >= startPort && config.Port < endPort {
 		logger.Fatalf("Cannot specify port %d, must be outside port range %d-%d", config.Port, 2000, 3000)
+	}
+	if config.TLS.Enabled && config.ChaincodeDevMode {
+		logger.Fatalf("Cannot enabled TLS and ChaincodeDevMode at the same.")
 	}
 	timeout, err := time.ParseDuration(config.TimeoutString)
 	if err != nil {

--- a/internal/app/microfabd/microfabd.go
+++ b/internal/app/microfabd/microfabd.go
@@ -617,6 +617,7 @@ func (m *Microfab) createAndStartPeer(organization *organization.Organization, a
 		fmt.Sprintf("http%s://%speer-operations.%s:%d", schemeSuffix, lowerOrganizationName, m.config.Domain, m.config.Port),
 		couchDB,
 		int32(couchDBProxyPort),
+		m.config.ChaincodeDevMode,
 	)
 	if err != nil {
 		return err

--- a/internal/pkg/peer/peer.go
+++ b/internal/pkg/peer/peer.go
@@ -16,24 +16,25 @@ import (
 
 // Peer represents a loaded peer definition.
 type Peer struct {
-	organization   *organization.Organization
-	identity       *identity.Identity
-	mspID          string
-	directory      string
-	apiPort        int32
-	apiURL         *url.URL
-	chaincodePort  int32
-	chaincodeURL   *url.URL
-	operationsPort int32
-	operationsURL  *url.URL
-	couchDB        bool
-	couchDBPort    int32
-	command        *exec.Cmd
-	tls            *identity.Identity
+	organization     *organization.Organization
+	identity         *identity.Identity
+	mspID            string
+	directory        string
+	apiPort          int32
+	apiURL           *url.URL
+	chaincodePort    int32
+	chaincodeURL     *url.URL
+	operationsPort   int32
+	operationsURL    *url.URL
+	couchDB          bool
+	couchDBPort      int32
+	command          *exec.Cmd
+	tls              *identity.Identity
+	chaincodeDevMode bool
 }
 
 // New creates a new peer.
-func New(organization *organization.Organization, directory string, apiPort int32, apiURL string, chaincodePort int32, chaincodeURL string, operationsPort int32, operationsURL string, couchDB bool, couchDBPort int32) (*Peer, error) {
+func New(organization *organization.Organization, directory string, apiPort int32, apiURL string, chaincodePort int32, chaincodeURL string, operationsPort int32, operationsURL string, couchDB bool, couchDBPort int32, chaincodeDevMode bool) (*Peer, error) {
 	identityName := fmt.Sprintf("%s Peer", organization.Name())
 	identity, err := identity.New(identityName, identity.WithOrganizationalUnit("peer"), identity.UsingSigner(organization.CA()))
 	if err != nil {
@@ -51,7 +52,7 @@ func New(organization *organization.Organization, directory string, apiPort int3
 	if err != nil {
 		return nil, err
 	}
-	return &Peer{organization, identity, organization.MSPID(), directory, apiPort, parsedAPIURL, chaincodePort, parsedChaincodeURL, operationsPort, parsedOperationsURL, couchDB, couchDBPort, nil, nil}, nil
+	return &Peer{organization, identity, organization.MSPID(), directory, apiPort, parsedAPIURL, chaincodePort, parsedChaincodeURL, operationsPort, parsedOperationsURL, couchDB, couchDBPort, nil, nil, chaincodeDevMode}, nil
 }
 
 // TLS gets the TLS identity for this peer.

--- a/internal/pkg/peer/peer_test.go
+++ b/internal/pkg/peer/peer_test.go
@@ -30,7 +30,7 @@ var _ = Describe("the peer package", func() {
 
 		When("called", func() {
 			It("creates a new peer", func() {
-				p, err := peer.New(testOrganization, testDirectory, 7051, "grpc://org1peer-api.127-0-0-1.nip.io:8080", 7052, "grpc://org1peer-chaincode.127-0-0-1.nip.io:8080", 8443, "http://org1peer-operations.127-0-0-1.nip.io:8080", false, 0)
+				p, err := peer.New(testOrganization, testDirectory, 7051, "grpc://org1peer-api.127-0-0-1.nip.io:8080", 7052, "grpc://org1peer-chaincode.127-0-0-1.nip.io:8080", 8443, "http://org1peer-operations.127-0-0-1.nip.io:8080", false, 0, true)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(p.Organization()).To(Equal(testOrganization))
 				Expect(p.MSPID()).To(Equal(testOrganization.MSPID()))
@@ -59,21 +59,21 @@ var _ = Describe("the peer package", func() {
 
 		When("called with an invalid API URL", func() {
 			It("returns an error", func() {
-				_, err := peer.New(testOrganization, testDirectory, 7051, "!@£$%^&*()_+", 7052, "grpc://org1peer-chaincode.127-0-0-1.nip.io:8080", 8443, "http://org1peer-operations.127-0-0-1.nip.io:8080", false, 0)
+				_, err := peer.New(testOrganization, testDirectory, 7051, "!@£$%^&*()_+", 7052, "grpc://org1peer-chaincode.127-0-0-1.nip.io:8080", 8443, "http://org1peer-operations.127-0-0-1.nip.io:8080", false, 0, true)
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		When("called with an invalid chaincode URL", func() {
 			It("returns an error", func() {
-				_, err := peer.New(testOrganization, testDirectory, 7051, "grpc://org1peer-api.127-0-0-1.nip.io:8080", 7052, "!@£$%^&*()_+", 8443, "http://org1peer-operations.127-0-0-1.nip.io:8080", false, 0)
+				_, err := peer.New(testOrganization, testDirectory, 7051, "grpc://org1peer-api.127-0-0-1.nip.io:8080", 7052, "!@£$%^&*()_+", 8443, "http://org1peer-operations.127-0-0-1.nip.io:8080", false, 0, true)
 				Expect(err).To(HaveOccurred())
 			})
 		})
 
 		When("called with an invalid operations URL", func() {
 			It("returns an error", func() {
-				_, err := peer.New(testOrganization, testDirectory, 7051, "grpc://org1peer-api.127-0-0-1.nip.io:8080", 7052, "grpc://org1peer-chaincode.127-0-0-1.nip.io:8080", 8443, "!@£$%^&*()_+", false, 0)
+				_, err := peer.New(testOrganization, testDirectory, 7051, "grpc://org1peer-api.127-0-0-1.nip.io:8080", 7052, "grpc://org1peer-chaincode.127-0-0-1.nip.io:8080", 8443, "!@£$%^&*()_+", false, 0, true)
 				Expect(err).To(HaveOccurred())
 			})
 		})

--- a/internal/pkg/peer/runtime.go
+++ b/internal/pkg/peer/runtime.go
@@ -40,7 +40,7 @@ func (p *Peer) Start(timeout time.Duration) error {
 	if err != nil {
 		return err
 	}
-	cmd := exec.Command("peer", "node", "start")
+	cmd := exec.Command("peer", "node", "start", fmt.Sprintf("--peer-chaincodedev=%v", p.chaincodeDevMode))
 	cmd.Env = os.Environ()
 	extraEnvs := []string{
 		fmt.Sprintf("FABRIC_CFG_PATH=%s", configDirectory),


### PR DESCRIPTION
This permits chaincodes to run and connect to the peer, without first being 'installed'.

Signed-off-by: Matthew B White <whitemat@uk.ibm.com>