### PR TITLE
Publish microfabd binary

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,3 +69,13 @@ jobs:
           docker push ibmcom/ibp-microfab:${VERSION}
           docker push ibmcom/ibp-microfab:latest
         if: startsWith(github.ref, 'refs/tags/')
+      - name: Build Binary
+        run: go build -v -o bin/microfabd cmd/microfabd/main.go
+      - name: Package Binary
+        run: |
+          tar -C bin -czvf microfab-${RUNNER_OS}-${RUNNER_ARCH}.tgz microfabd
+      - name: Publish Binary to GitHub Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: microfab-*.tgz

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 #
 
 # Binaries for programs and plugins
+/bin
 *.exe
 *.exe~
 *.dll


### PR DESCRIPTION
Build and publish the microfabd binary in addition to the pre-canned docker image for use in other environments

Signed-off-by: James Taylor <jamest@uk.ibm.com>